### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ There are several different ways to get the code. Some examples below:
 #### CDN
 Dirty Forms is available over jsDelivr CDN and can directly included to every page.
 ```HTML
-<script type="text/javascript" src="//cdn.jsdelivr.net/jquery.facebox/1.4.1/jquery.facebox.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/jquery.facebox@1.4.1/jquery.facebox.min.js"></script>
 ```
 
 jsDelivr also supports [on-the-fly concatenation of files](https://github.com/jsdelivr/jsdelivr#load-multiple-files-with-single-http-request), so you can reference only 1 URL to get jQuery and jquery.facebox in one request.
 ```HTML
-<script type="text/javascript" src="//cdn.jsdelivr.net/g/jquery@1.11.3,jquery.facebox@1.4.1"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/combine/npm/jquery@1.11.3,npm/jquery.facebox@1.4.1"></script>
 ```
 
 #### Self-Hosted
@@ -74,7 +74,7 @@ A [SourceMap](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-
 ####CDN
 
 ```HTML
-<script type="text/javascript" src="//cdn.jsdelivr.net/jquery.facebox/1.4.1/jquery.facebox.min.js.map"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/jquery.facebox@1.4.1/jquery.facebox.min.js.map"></script>
 ```
 
 #### Package Managers

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dirty Forms is available over jsDelivr CDN and can directly included to every pa
 <script type="text/javascript" src="//cdn.jsdelivr.net/npm/jquery.facebox@1.4.1/jquery.facebox.min.js"></script>
 ```
 
-jsDelivr also supports [on-the-fly concatenation of files](https://github.com/jsdelivr/jsdelivr#load-multiple-files-with-single-http-request), so you can reference only 1 URL to get jQuery and jquery.facebox in one request.
+jsDelivr also supports [on-the-fly concatenation of files](https://www.jsdelivr.com/features#combine), so you can reference only 1 URL to get jQuery and jquery.facebox in one request.
 ```HTML
 <script type="text/javascript" src="//cdn.jsdelivr.net/combine/npm/jquery@1.11.3,npm/jquery.facebox@1.4.1"></script>
 ```
@@ -74,7 +74,7 @@ A [SourceMap](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-
 ####CDN
 
 ```HTML
-<script type="text/javascript" src="//cdn.jsdelivr.net/npm/jquery.facebox@1.4.1/jquery.facebox.min.js.map"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/jquery.facebox@1.4.1/jquery.facebox.min.js"></script>
 ```
 
 #### Package Managers


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jquery.facebox.

Feel free to ping me if you have any questions regarding this change.